### PR TITLE
CSS tweaks for mobile views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _site
 .sass-cache
 .jekyll-metadata
 .DS_Store
+vendor/bundle
+.bundle/config

--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,7 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - content
+  - vendor
 
 defaults:
   -

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -1,3 +1,6 @@
+$mobile-width: 767px;
+$narrow-phone-width: 400px;
+
 a {
   text-decoration: none;
   &:hover {
@@ -30,14 +33,6 @@ body, html {
   margin: 5px 5px 0;
 }
 
-.red-container {
-  background: #A31F34;
-  margin: 5px;
-  min-height: 150px;
-  height: 150px;
-  display: flex;
-}
-
 .bg-img {
   flex: 1;
   background: url('/assets/images/marching.png');
@@ -55,20 +50,45 @@ body, html {
   padding: 15px 30px;
 }
 
-.nav-menu {
-  margin: auto; /* Important */
-  text-align: center;
+.red-container {
+  background: #A31F34;
+  margin: 5px;
+  min-height: 150px;
+  height: 150px;
+  display: flex;
+
+  @media screen and (max-width: $mobile-width) {
+    height: 100px;
+    min-height: 100px;
+  }
+  @media screen and (max-width: $narrow-phone-width) {
+    height: 80px;
+    min-height: 80px;
+  }
 }
 
-.nav-menu a {
-  display: inline-block;
-  margin: 0 1em;
-  color: white;
-  font-size: 48px;
-  @media (max-width: 767px) {
-    font-size: 36px;
-    display: block;
+nav.nav-menu {
+  margin: auto; /* Important */
+  text-align: center;
+  display: flex;
+
+  a {
+    display: inline-block;
+    margin: 0 1em;
+    color: white;
+    font-size: 48px;
+
+    @media screen and (max-width: $mobile-width) {
+      font-size: 32px;
+      display: block;
+      margin: 0 0.5em;
+    }
+
+    @media screen and (max-width: $narrow-phone-width) {
+      font-size: 28px;
+    }
+
+    line-height: 1;
+    font-weight: bold;
   }
-  line-height: 1;
-  font-weight: bold;
 }


### PR DESCRIPTION
just a few CSS tweaks to make the top bar display in a landscape layout on mobile, some sizing tweaks, etc.

before:

![mitsawiphone6before](https://user-images.githubusercontent.com/6207644/66761802-bad95b00-ee72-11e9-9106-aa9fc585d766.png)
![mitsawiphone5before](https://user-images.githubusercontent.com/6207644/66761803-bb71f180-ee72-11e9-9c70-aa8bcb8a9bb3.png)
![mitsawiphone6plus](https://user-images.githubusercontent.com/6207644/66761805-bb71f180-ee72-11e9-85ec-0b692557752a.png)

after:

![mitsawiphone6plus](https://user-images.githubusercontent.com/6207644/66761815-c298ff80-ee72-11e9-912c-b527c487f8f7.png)
![mitsawiphone6](https://user-images.githubusercontent.com/6207644/66761816-c3319600-ee72-11e9-9948-3ee3e6bf29e2.png)
![mitsawiphone5](https://user-images.githubusercontent.com/6207644/66761817-c3319600-ee72-11e9-9768-172ed137379e.png)

I just tested using the chrome device simulator for iphone 5, 6, 6plus.

I also made a few small tweaks to the config to support using a vendored bundle install.